### PR TITLE
feat: 变更 loading 样式为 3 个小圆点

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -9,7 +9,7 @@
 
 日志查看组件，将终端日志内容展示在页面中
 
-![1.gif](https://cdn.nlark.com/yuque/0/2019/gif/298847/1563414930214-34da6e0b-bdbe-4c59-b531-772afa146417.gif#align=left&display=inline&height=837&name=1.gif&originHeight=837&originWidth=1118&size=78547&status=done&width=1118)
+![new-log](https://user-images.githubusercontent.com/53422750/65296811-4cb5b700-db98-11e9-9b55-1a5c8633ae8f.gif)
 
 [English](./README-en.md)
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 log-viewer is a vue component which can display terminal log in browser with high performance.
 
-![1.gif](https://cdn.nlark.com/yuque/0/2019/gif/298847/1563414930214-34da6e0b-bdbe-4c59-b531-772afa146417.gif#align=left&display=inline&height=837&name=1.gif&originHeight=837&originWidth=1118&size=78547&status=done&width=1118)
+![new-log](https://user-images.githubusercontent.com/53422750/65296811-4cb5b700-db98-11e9-9b55-1a5c8633ae8f.gif)
 
 [中文文档](./README-zh.md)
 

--- a/src/components/loading.vue
+++ b/src/components/loading.vue
@@ -6,19 +6,12 @@
         <span>•</span>
         <span>•</span>
       </span>
-      <span>{{ loadingText }}</span>
     </slot>
   </span>
 </template>
 <script>
 export default {
-  name: 'LogLoading',
-  props: {
-    loadingText: {
-      type: String,
-      default: 'loading...'
-    }
-  }
+  name: 'LogLoading'
 }
 </script>
 

--- a/src/components/loading.vue
+++ b/src/components/loading.vue
@@ -1,9 +1,11 @@
 <template>
   <span class="log-loading">
     <slot>
-      <svg class="circular" viewBox="25 25 50 50">
-        <circle class="path" cx="50" cy="50" r="20" fill="none" />
-      </svg>
+      <span class="loading-dots">
+        <span>•</span>
+        <span>•</span>
+        <span>•</span>
+      </span>
       <span>{{ loadingText }}</span>
     </slot>
   </span>
@@ -19,56 +21,42 @@ export default {
   }
 }
 </script>
+
 <style lang="less">
 .log-loading {
-  .circular {
-    height: 10px;
-    width: 10px;
-    -webkit-animation: log-loading 2s linear infinite;
-    animation: log-loading 2s linear infinite;
-    // 位置相关
+  .loading-dots {
     margin-right: 3px;
 
-    .path {
-      -webkit-animation: loading-dash 1.5s ease-in-out infinite;
-      animation: loading-dash 1.5s ease-in-out infinite;
-      stroke-dasharray: 90, 150;
-      stroke-dashoffset: 0;
-      stroke-width: 2;
-      stroke: #d6d6d6;
-      stroke-linecap: round;
+    span {
+      animation: blink 1.4s infinite both;
+      margin-left: -1px;
+
+      &:first-child {
+        margin-left: 0;
+      }
+
+      &:nth-child(2) {
+        animation-delay: 0.2s;
+      }
+
+      &:nth-child(3) {
+        animation-delay: 0.4s;
+      }
     }
-  }
-}
 
-@keyframes log-loading {
-  0% {
-    transform: rotate(0deg);
-  }
+    @keyframes blink {
+      0% {
+        opacity: 0.2;
+      }
 
-  50% {
-    transform: rotate(180deg);
-  }
+      20% {
+        opacity: 1;
+      }
 
-  100% {
-    transform: rotate(360deg);
-  }
-}
-
-@keyframes loading-dash {
-  0% {
-    stroke-dasharray: 1, 200;
-    stroke-dashoffset: 0;
-  }
-
-  50% {
-    stroke-dasharray: 90, 150;
-    stroke-dashoffset: -40px;
-  }
-
-  100% {
-    stroke-dasharray: 90, 150;
-    stroke-dashoffset: -120px;
+      100% {
+        opacity: 0.2;
+      }
+    }
   }
 }
 </style>


### PR DESCRIPTION
![loading-dots](https://user-images.githubusercontent.com/53422750/65231922-dfa41200-db02-11e9-988d-a1de6188ee6a.gif)


## Why

- 根据内部针对 Log Viewer 组件优化与迭代计划
- 外观灵感来源
  - zeit/design loading-dots
- 变更灵感来源
  - gitlab CI
  - travis CI
  - 以及其他...

## How

![image](https://user-images.githubusercontent.com/53422750/65229473-eb8dd500-dafe-11e9-9e4f-78d6a225c019.png)

## Test

```console
$ jest --verbose
 PASS  test/utils/index.test.js
  src/utils/index.js
    ✓ 根据换行符切割字符串 (6ms)
    ✓ 去除开头的控制符 (1ms)
    ✓ 去除尾部的控制符 (1ms)
    ✓ 删除K控制符之前的同一行内容 (2ms)
    ✓ 删除光标控制符

Test Suites: 1 passed, 1 total
Tests:       5 passed, 5 total
Snapshots:   0 total
Time:        3.892s
Ran all test suites.
```

## Docs

- README.md README-zh.md 变更 gif

![new-log](https://user-images.githubusercontent.com/53422750/65296811-4cb5b700-db98-11e9-9b55-1a5c8633ae8f.gif)

## Inspiration

- [zeit/design's loading-dots](https://zeit.co/design/loading-dots)
