### PR TITLE
chore: build with autoprefixer

### DIFF
--- a/build/rollup.config.js
+++ b/build/rollup.config.js
@@ -17,7 +17,10 @@ const config = {
     commonjs(),
     vue({
       css: true,
-      compileTemplate: true
+      compileTemplate: true,
+      style: {
+        postcssPlugins: [require('autoprefixer')]
+      }
     }),
     babel({
       runtimeHelpers: true,


### PR DESCRIPTION
## Why
add vendor prefix

## How
see docs
1. https://rollup-plugin-vue.vuejs.org/options.html#style-postcssmodulesoptions
2. https://github.com/postcss/autoprefixer#webpack

项目里有 stylelint, 它依赖了了 autoprefixer，故不需要安装 autoprefixer 依赖

## Test
![image](https://user-images.githubusercontent.com/9384365/67076137-2434d300-f1bf-11e9-925f-9938813f7c51.png)
