### PR TITLE
fix: 开头空格不显示

### DIFF
--- a/src/components/line-content.vue
+++ b/src/components/line-content.vue
@@ -1,7 +1,5 @@
 <template>
-  <div class="line-content" :class="className">
-    {{ text }}
-  </div>
+  <div class="line-content" :class="className">{{ text }}</div>
 </template>
 <script>
 export default {

--- a/src/components/line-wrapper.vue
+++ b/src/components/line-wrapper.vue
@@ -63,7 +63,7 @@ export default {
   color: #f1f1f1;
   line-height: 20px;
   height: 20px;
-  white-space: nowrap;
+  white-space: pre;
   // word-break: break-all;
   box-sizing: border-box;
   padding-left: 16px;
@@ -86,7 +86,6 @@ export default {
 
   .line-content {
     display: inline-block;
-    white-space: pre;
   }
 }
 </style>

--- a/src/components/line-wrapper.vue
+++ b/src/components/line-wrapper.vue
@@ -86,6 +86,7 @@ export default {
 
   .line-content {
     display: inline-block;
+    white-space: pre;
   }
 }
 </style>


### PR DESCRIPTION
<!--- 
please use Conventional Commits： https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits

- 
- fix: A bug fix





-->
## Why
日志开头空格没有显示导致日志内容可读性差了

![image](https://user-images.githubusercontent.com/19562649/69395819-4b7d4380-0d1b-11ea-89b0-b4ca790d967b.png)


## How
增加样式显示开头空格
`white-space: pre;`

## Test
修改后效果
![image](https://user-images.githubusercontent.com/19562649/69395910-8e3f1b80-0d1b-11ea-9c97-c6e4c058d792.png)

