### PR TITLE
fix: safari中，使用white-space时，超出一行的文字重叠了

### DIFF
--- a/src/components/line-wrapper.vue
+++ b/src/components/line-wrapper.vue
@@ -62,6 +62,7 @@ export default {
 </script>
 <style lang="less">
 .line-wrapper {
+  display: flex;
   color: #f1f1f1;
   line-height: 20px;
   height: 20px;
@@ -75,19 +76,14 @@ export default {
   }
 
   .line-number {
-    display: inline-block;
     min-width: 40px;
     text-align: right;
     color: #666;
-    padding-right: 8px;
+    padding-right: 10px;
     -webkit-user-select: none;
     -moz-user-select: none;
     -ms-user-select: none;
     user-select: none;
-  }
-
-  .line-content {
-    display: inline-block;
   }
 }
 </style>


### PR DESCRIPTION
<!--- 
please use Conventional Commits： https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits
-->

## Why
在Safari下，样式问题
![image](https://user-images.githubusercontent.com/12596622/74329769-62d44600-4dcb-11ea-8d49-8767199c862e.png)

## How
1. 如commit
2. .line-number的padding-right调整为10px，目的是和之前的样式保持间距一致(inline-block元素间距）

## Test
![image](https://user-images.githubusercontent.com/12596622/74331085-dbd49d00-4dcd-11ea-8b97-22f92caa927a.png)

## Docs
It there requires a change to the documentation？
